### PR TITLE
Multi-page PDF support

### DIFF
--- a/docs/reference/pytest_plugin.md
+++ b/docs/reference/pytest_plugin.md
@@ -3,7 +3,8 @@
 ::: tinyvdiff.pytest_plugin
     options:
       members:
-        - pytest_addoption
+        - TinyVDiff
         - tinyvdiff
+        - pytest_addoption
       show_root_heading: true
-      show_source: true
+      show_source: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ authors = [
 ]
 dependencies = [
     "pytest>=8.3.3",
+    "pypdf>=5.1.0",
 ]
 readme = "README.md"
 

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -272,6 +272,8 @@ pymdown-extensions==10.12
     # via mkdocstrings
 pyparsing==3.2.0
     # via matplotlib
+pypdf==5.1.0
+    # via tinyvdiff
 pytest==8.3.4
     # via tinyvdiff
 python-dateutil==2.9.0.post0

--- a/requirements.lock
+++ b/requirements.lock
@@ -16,5 +16,7 @@ packaging==24.2
     # via pytest
 pluggy==1.5.0
     # via pytest
+pypdf==5.1.0
+    # via tinyvdiff
 pytest==8.3.4
     # via tinyvdiff

--- a/src/tinyvdiff/pdf.py
+++ b/src/tinyvdiff/pdf.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+from pypdf import PdfReader
+
+
+def get_pdf_page_count(pdf_path: str | Path) -> int:
+    """
+    Get the number of pages in a PDF file.
+
+    Args:
+        pdf_path (str | Path): Path to the PDF file. Can include ~ for home directory.
+
+    Returns:
+        int: Number of pages in the PDF file
+
+    Raises:
+        FileNotFoundError: If the PDF file does not exist
+        ValueError: If the file is not a valid PDF
+    """
+    # Convert to Path and expand user home directory and resolve symlinks
+    pdf_path = Path(pdf_path).expanduser().resolve()
+
+    if not pdf_path.exists():
+        raise FileNotFoundError(f"PDF file not found: {pdf_path}")
+
+    try:
+        reader = PdfReader(str(pdf_path))
+        return len(reader.pages)
+    except Exception as e:
+        raise ValueError(f"Invalid PDF file: {pdf_path}") from e

--- a/src/tinyvdiff/pdf.py
+++ b/src/tinyvdiff/pdf.py
@@ -8,16 +8,15 @@ def get_pdf_page_count(pdf_path: str | Path) -> int:
     Get the number of pages in a PDF file.
 
     Args:
-        pdf_path (str | Path): Path to the PDF file. Can include ~ for home directory.
+        pdf_path (str | Path): Path to the PDF file.
 
     Returns:
-        int: Number of pages in the PDF file
+        int: Number of pages in the PDF file.
 
     Raises:
-        FileNotFoundError: If the PDF file does not exist
-        ValueError: If the file is not a valid PDF
+        FileNotFoundError: If the PDF file does not exist.
+        ValueError: If the file is not a valid PDF.
     """
-    # Convert to Path and expand user home directory and resolve symlinks
     pdf_path = Path(pdf_path).expanduser().resolve()
 
     if not pdf_path.exists():

--- a/src/tinyvdiff/pytest_plugin.py
+++ b/src/tinyvdiff/pytest_plugin.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 
+from .pdf import get_pdf_page_count
 from .pdf2svg import PDF2SVG
 from .snapshot import compare_svgs, update_snapshot
 
@@ -20,8 +21,62 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
 
 
+class TinyVDiff:
+    """Helper class for visual regression testing with PDFs."""
+
+    def __init__(self, request: pytest.FixtureRequest) -> None:
+        """Initialize TinyVDiff with configuration from pytest."""
+        self.pdf2svg = PDF2SVG()
+        self.update_snapshots = request.config.getoption("--tinyvdiff-update")
+        # Determine the snapshot directory relative to the test file
+        self.snapshot_dir = Path(request.node.fspath).parent / "snapshots"
+
+    def assert_pdf_snapshot(self, pdf_path: Path | str, snapshot_name: str) -> None:
+        """Assert that a PDF matches its stored snapshot.
+
+        Converts each page of the PDF to SVG and compares it with stored
+        snapshots, updating the snapshots if requested via `--tinyvdiff-update`.
+
+        Args:
+            pdf_path: Path to the PDF file to test.
+            snapshot_name: Base name for the snapshot files.
+                For multi-page PDFs, page number will be inserted before file
+                extension. For example, a two-page `test.pdf` becomes
+                `test_p1.svg` and `test_p2.svg`.
+
+        Raises:
+            pytest.Failed: If snapshots do not match and updates are not enabled.
+        """
+        num_pages = get_pdf_page_count(pdf_path)
+        if num_pages == 0:
+            pytest.fail(f"PDF file has no pages: {pdf_path}")
+
+        # Split snapshot name into base and extension for multi-page handling
+        snapshot_base = Path(snapshot_name)
+        snapshot_stem = snapshot_base.stem
+        snapshot_suffix = snapshot_base.suffix
+
+        for page in range(1, num_pages + 1):
+            # Generate page-specific snapshot name
+            page_snapshot_name = (
+                f"{snapshot_stem}_p{page}{snapshot_suffix}"
+                if num_pages > 1
+                else snapshot_name
+            )
+            snapshot_path = self.snapshot_dir / page_snapshot_name
+
+            # Convert specific PDF page to SVG
+            svg_generated = self.pdf2svg.convert(pdf_path, page=page)
+
+            if self.update_snapshots or not snapshot_path.exists():
+                update_snapshot(svg_generated, snapshot_path)
+            else:
+                if not compare_svgs(svg_generated, snapshot_path):
+                    pytest.fail(f"Snapshot mismatch for {page_snapshot_name}")
+
+
 @pytest.fixture
-def tinyvdiff(request: pytest.FixtureRequest) -> "TinyVDiff":
+def tinyvdiff(request: pytest.FixtureRequest) -> TinyVDiff:
     """Pytest fixture providing TinyVDiff functionality.
 
     Args:
@@ -30,38 +85,4 @@ def tinyvdiff(request: pytest.FixtureRequest) -> "TinyVDiff":
     Returns:
         Configured TinyVDiff instance for the current test.
     """
-
-    class TinyVDiff:
-        """Helper class for visual regression testing with PDFs."""
-
-        def __init__(self) -> None:
-            """Initialize TinyVDiff with configuration from pytest."""
-            self.pdf2svg = PDF2SVG()
-            self.update_snapshots = request.config.getoption("--tinyvdiff-update")
-            # Determine the snapshot directory relative to the test file
-            self.snapshot_dir = Path(request.node.fspath).parent / "snapshots"
-
-        def assert_pdf_snapshot(self, pdf_path: Path | str, snapshot_name: str) -> None:
-            """Assert that a PDF matches its stored snapshot.
-
-            Converts the PDF to SVG and compares it with a stored snapshot,
-            updating the snapshot if requested via `--tinyvdiff-update`.
-
-            Args:
-                pdf_path: Path to the PDF file to test.
-                snapshot_name: Name of the snapshot file to compare against.
-
-            Raises:
-                pytest.Failed: If snapshots don't match and updates aren't enabled.
-            """
-            # Convert PDF to SVG
-            svg_generated = self.pdf2svg.convert(pdf_path)
-            snapshot_path = self.snapshot_dir / snapshot_name
-
-            if self.update_snapshots or not snapshot_path.exists():
-                update_snapshot(svg_generated, snapshot_path)
-            else:
-                if not compare_svgs(svg_generated, snapshot_path):
-                    pytest.fail(f"Snapshot mismatch for {snapshot_name}")
-
-    return TinyVDiff()
+    return TinyVDiff(request)

--- a/tests/snapshot_fpdf2.py
+++ b/tests/snapshot_fpdf2.py
@@ -4,7 +4,7 @@
 from fpdf import FPDF
 
 
-def generate_fpdf2(data, output_file):
+def generate_pdf_single_page(data, output_file):
     pdf = FPDF()
     pdf.add_page()
     pdf.set_font("times", size=14)
@@ -14,6 +14,29 @@ def generate_fpdf2(data, output_file):
             table_row = table.row()
             for cell in row:
                 table_row.cell(cell)
+
+    pdf.output(output_file)
+    return output_file
+
+
+def generate_pdf_multi_page(output_file, num_pages=2, content_prefix="Page"):
+    """Generate a multi-page PDF for testing.
+
+    Args:
+        output_file: Path to save the PDF.
+        num_pages: Number of pages to generate.
+        content_prefix: Prefix for page content to allow generating different content.
+
+    Returns:
+        Path to the generated PDF file.
+    """
+    pdf = FPDF()
+    pdf.set_font("times", size=14)
+
+    for i in range(num_pages):
+        pdf.add_page()
+        pdf.text(10, 20, f"{content_prefix} {i + 1} content")
+        pdf.text(10, 50, f"This is a test page {i + 1}")
 
     pdf.output(output_file)
     return output_file

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+import pytest
+from fpdf import FPDF
+
+from tinyvdiff.pdf import get_pdf_page_count
+
+
+def create_test_pdf(output_path: Path, num_pages: int) -> Path:
+    """Helper function to create a PDF with specified number of pages"""
+    pdf = FPDF()
+    for i in range(num_pages):
+        pdf.add_page()
+        pdf.set_font("times", size=16)
+        pdf.text(10, 20, f"Test page {i + 1}")
+    pdf.output(str(output_path))
+    return output_path
+
+
+def test_get_pdf_page_count_single_page(tmp_path):
+    pdf_path = tmp_path / "single_page.pdf"
+    create_test_pdf(pdf_path, 1)
+    assert get_pdf_page_count(pdf_path) == 1
+
+
+def test_get_pdf_page_count_multiple_pages(tmp_path):
+    pdf_path = tmp_path / "multi_page.pdf"
+    create_test_pdf(pdf_path, 5)
+    assert get_pdf_page_count(pdf_path) == 5
+
+
+def test_get_pdf_page_count_missing_file(tmp_path):
+    pdf_path = tmp_path / "nonexistent.pdf"
+    with pytest.raises(FileNotFoundError):
+        get_pdf_page_count(pdf_path)
+
+
+def test_get_pdf_page_count_invalid_file(tmp_path):
+    invalid_pdf = tmp_path / "invalid.pdf"
+    invalid_pdf.write_text("This is not a PDF file")
+
+    with pytest.raises(ValueError):
+        get_pdf_page_count(invalid_pdf)
+
+
+def test_get_pdf_page_count_string_path(tmp_path):
+    pdf_path = str(tmp_path / "nonexistent.pdf")
+    with pytest.raises(FileNotFoundError):
+        get_pdf_page_count(pdf_path)

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -5,7 +5,7 @@ import uuid
 import pytest
 
 from .snapshot_matplotlib import generate_plot
-from .snapshot_fpdf2 import generate_fpdf2, data
+from .snapshot_fpdf2 import generate_pdf_single_page, generate_pdf_multi_page, data
 
 macos_only = pytest.mark.skipif(
     platform.system() != "Darwin", reason="These snapshots are generated on macOS"
@@ -20,16 +20,61 @@ def temp_pdf(tmp_path):
 
 @macos_only
 def test_matplotlib_visual(tinyvdiff, temp_pdf):
-    """Test visual regression with matplotlib-generated PDF"""
+    """Test visual regression with single-page PDF generated with matplotlib"""
     pdf_path = generate_plot(temp_pdf)
     tinyvdiff.assert_pdf_snapshot(pdf_path, "snapshot_matplotlib.svg")
 
 
 @macos_only
-def test_fpdf_visual(tinyvdiff, temp_pdf):
-    """Test visual regression with fpdf2-generated PDF"""
-    pdf_path = generate_fpdf2(data, temp_pdf)
+def test_fpdf2_single_page_visual(tinyvdiff, temp_pdf):
+    """Test visual regression with single-page PDF generated with fpdf2"""
+    pdf_path = generate_pdf_single_page(data, temp_pdf)
     tinyvdiff.assert_pdf_snapshot(pdf_path, "snapshot_fpdf2.svg")
+
+
+@macos_only
+def test_fpdf2_multi_page_visual(tinyvdiff, temp_pdf):
+    """Test visual regression with multi-page PDF generated with fpdf2"""
+    pdf_path = generate_pdf_multi_page(temp_pdf, num_pages=3)
+    snapshot_name = "snapshot_multipage.svg"
+
+    # First run should create snapshots
+    tinyvdiff.assert_pdf_snapshot(pdf_path, snapshot_name)
+
+    # Verify that all page snapshots were created
+    for i in range(1, 4):
+        snapshot_path = Path(tinyvdiff.snapshot_dir) / f"snapshot_multipage_p{i}.svg"
+        assert snapshot_path.exists()
+        snapshot_path.unlink()
+
+
+@macos_only
+def test_fpdf2_multi_page_mismatch(tinyvdiff, temp_pdf):
+    """Test that mismatches are detected in multi-page PDFs generated with fpdf2"""
+    # Create initial PDF and snapshot
+    pdf_path = generate_pdf_multi_page(temp_pdf, num_pages=2)
+    snapshot_name = f"test_mismatch_multi_{uuid.uuid4()}.svg"
+
+    tinyvdiff.update_snapshots = True
+    tinyvdiff.assert_pdf_snapshot(pdf_path, snapshot_name)
+    tinyvdiff.update_snapshots = False
+
+    # Create different PDF with same number of pages
+    different_pdf = generate_pdf_multi_page(
+        temp_pdf, num_pages=2, content_prefix="Different"
+    )
+
+    # Should fail due to content mismatch
+    with pytest.raises(pytest.fail.Exception):
+        tinyvdiff.assert_pdf_snapshot(different_pdf, snapshot_name)
+
+    # Clean up snapshot files
+    for i in range(1, 3):
+        snapshot_path = (
+            Path(tinyvdiff.snapshot_dir)
+            / f"{Path(snapshot_name).stem}_p{i}{Path(snapshot_name).suffix}"
+        )
+        snapshot_path.unlink()
 
 
 def test_missing_snapshot(tinyvdiff, temp_pdf):
@@ -56,14 +101,14 @@ def test_update_snapshot(tinyvdiff, tmp_path):
     original_pdf = tmp_path / "original.pdf"
     updated_pdf = tmp_path / "updated.pdf"
 
-    # First generate and save a snapshot with fpdf2 data
-    pdf_path = generate_fpdf2(data, original_pdf)
+    # First generate and save a snapshot with original data
+    pdf_path = generate_pdf_single_page(data, original_pdf)
     tinyvdiff.assert_pdf_snapshot(pdf_path, snapshot_name)
 
     # Generate a different PDF and update snapshot with --tinyvdiff-update flag
     updated_data = [["Updated", "Header"], ["Updated", "Data"]]
     tinyvdiff.update_snapshots = True
-    new_pdf_path = generate_fpdf2(updated_data, updated_pdf)
+    new_pdf_path = generate_pdf_single_page(updated_data, updated_pdf)
     tinyvdiff.assert_pdf_snapshot(new_pdf_path, snapshot_name)
     tinyvdiff.update_snapshots = False  # Reset update flag
 
@@ -81,8 +126,8 @@ def test_update_snapshot(tinyvdiff, tmp_path):
 
 def test_snapshot_mismatch(tinyvdiff, temp_pdf):
     """Test that mismatched snapshots are detected"""
-    # First generate and save a snapshot using fpdf2 data
-    pdf_path = generate_fpdf2(data, temp_pdf)
+    # First generate and save a snapshot using original data
+    pdf_path = generate_pdf_single_page(data, temp_pdf)
     snapshot_name = "test_mismatch.svg"
 
     # Force update for the first snapshot
@@ -95,7 +140,7 @@ def test_snapshot_mismatch(tinyvdiff, temp_pdf):
         ["Different", "Header", "Here"],
         ["Different", "Data", "Row"],
     ]
-    different_pdf = generate_fpdf2(different_data, temp_pdf)
+    different_pdf = generate_pdf_single_page(different_data, temp_pdf)
 
     # Test should fail due to mismatch
     with pytest.raises(pytest.fail.Exception):


### PR DESCRIPTION
Fixes #9 

This PR refactors the pytest plugin to handle multi-page PDF files properly.

Each multi-page PDF will correspond to SVG snapshots with file name suffixes `_p1.svg`, `_p2.svg`, ...