### PR TITLE
Run isort and ruff format

### DIFF
--- a/docs/scripts/sync.sh
+++ b/docs/scripts/sync.sh
@@ -1,7 +1,7 @@
 #!/bin/zsh
 
 # Sync README.md with modified image path for docs/index.md
-awk '{gsub("docs/assets/logo.png", "assets/logo.png"); print}' README.md > docs/index.md
+awk '{gsub("docs/assets/logo.png", "assets/logo.png"); print}' README.md >docs/index.md
 
 # Sync CHANGELOG.md with docs/changelog.md
 cp CHANGELOG.md docs/changelog.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ build-backend = "hatchling.build"
 [tool.rye]
 managed = true
 dev-dependencies = [
-    "ruff>=0.8.0",
     "mkdocs>=1.6.1",
     "mkdocs-autorefs==1.2.0",
     "mkdocs-material>=9.5.46",
@@ -58,6 +57,8 @@ dev-dependencies = [
     "numpy>=2.1.3",
     "matplotlib>=3.9.3",
     "fpdf2>=2.8.1",
+    "ruff>=0.8.0",
+    "isort>=5.13.2",
 ]
 
 [tool.hatch.metadata]

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -25,7 +25,7 @@ asttokens==3.0.0
     # via stack-data
 async-lru==2.0.4
     # via jupyterlab
-attrs==24.3.0
+attrs==25.1.0
     # via jsonschema
     # via referencing
 babel==2.16.0
@@ -65,11 +65,11 @@ decorator==5.1.1
 defusedxml==0.7.1
     # via fpdf2
     # via nbconvert
-executing==2.1.0
+executing==2.2.0
     # via stack-data
 fastjsonschema==2.21.1
     # via nbformat
-fonttools==4.55.3
+fonttools==4.55.6
     # via fpdf2
     # via matplotlib
 fpdf2==2.8.2
@@ -195,7 +195,7 @@ mkdocs-autorefs==1.2.0
     # via mkdocstrings-python
 mkdocs-get-deps==0.2.0
     # via mkdocs
-mkdocs-material==9.5.49
+mkdocs-material==9.5.50
 mkdocs-material-extensions==1.3.1
     # via mkdocs-material
 mkdocstrings==0.27.0
@@ -217,7 +217,7 @@ notebook==7.3.2
 notebook-shim==0.2.4
     # via jupyterlab
     # via notebook
-numpy==2.2.1
+numpy==2.2.2
     # via contourpy
     # via matplotlib
 overrides==7.7.0
@@ -252,7 +252,7 @@ pluggy==1.5.0
     # via pytest
 prometheus-client==0.21.1
     # via jupyter-server
-prompt-toolkit==3.0.48
+prompt-toolkit==3.0.50
     # via ipython
     # via jupyter-console
 psutil==6.1.1
@@ -269,7 +269,7 @@ pygments==2.19.1
     # via jupyter-console
     # via mkdocs-material
     # via nbconvert
-pymdown-extensions==10.14
+pymdown-extensions==10.14.1
     # via mkdocs-material
     # via mkdocstrings
 pyparsing==3.2.1
@@ -300,7 +300,7 @@ pyzmq==26.2.0
     # via jupyter-client
     # via jupyter-console
     # via jupyter-server
-referencing==0.36.1
+referencing==0.36.2
     # via jsonschema
     # via jsonschema-specifications
     # via jupyter-events
@@ -318,7 +318,7 @@ rfc3986-validator==0.1.1
 rpds-py==0.22.3
     # via jsonschema
     # via referencing
-ruff==0.9.2
+ruff==0.9.3
 send2trash==1.8.3
     # via jupyter-server
 setuptools==75.8.0

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -104,6 +104,7 @@ ipywidgets==8.1.5
     # via jupyter
 isoduration==20.11.0
     # via jsonschema
+isort==5.13.2
 jedi==0.19.2
     # via ipython
 jinja2==3.1.5

--- a/src/tinyvdiff/__init__.py
+++ b/src/tinyvdiff/__init__.py
@@ -5,4 +5,4 @@ tinyvdiff - Minimalist visual regression testing plugin for pytest
 from .pdf import get_pdf_page_count
 from .pdf2svg import PDF2SVG
 from .pytest_plugin import TinyVDiff
-from .snapshot import normalize_svg, compare_svgs, update_snapshot
+from .snapshot import compare_svgs, normalize_svg, update_snapshot

--- a/tests/test_pdf2svg.py
+++ b/tests/test_pdf2svg.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from tinyvdiff.pdf2svg import PDF2SVG
+
 from .snapshot_fpdf2 import generate_pdf_multi_page
 
 

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -1,11 +1,11 @@
-from pathlib import Path
 import platform
 import uuid
+from pathlib import Path
 
 import pytest
 
+from .snapshot_fpdf2 import data, generate_pdf_multi_page, generate_pdf_single_page
 from .snapshot_matplotlib import generate_plot
-from .snapshot_fpdf2 import generate_pdf_single_page, generate_pdf_multi_page, data
 
 macos_only = pytest.mark.skipif(
     platform.system() != "Darwin", reason="These snapshots are generated on macOS"

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tinyvdiff.snapshot import normalize_svg, compare_svgs, update_snapshot
+from tinyvdiff.snapshot import compare_svgs, normalize_svg, update_snapshot
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR runs

```bash
isort .
ruff format
```

to sort imports and format Python code.

Also runs shell-format to format the Bash scripts.