### PR TITLE
Use absolute URL logo in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# tinyvdiff <img src="docs/assets/logo.png" align="right" width="120" />
+# tinyvdiff <img src="https://github.com/nanxstats/tinyvdiff/raw/main/docs/assets/logo.png" align="right" width="120" />
 
 [![PyPI version](https://img.shields.io/pypi/v/tinyvdiff)](https://pypi.org/project/tinyvdiff/)
 ![Python versions](https://img.shields.io/pypi/pyversions/tinyvdiff)

--- a/docs/scripts/sync.sh
+++ b/docs/scripts/sync.sh
@@ -1,7 +1,7 @@
 #!/bin/zsh
 
 # Sync README.md with modified image path for docs/index.md
-awk '{gsub("docs/assets/logo.png", "assets/logo.png"); print}' README.md >docs/index.md
+awk '{gsub("https://github.com/nanxstats/tinyvdiff/raw/main/docs/assets/logo.png", "assets/logo.png"); print}' README.md >docs/index.md
 
 # Sync CHANGELOG.md with docs/changelog.md
 cp CHANGELOG.md docs/changelog.md

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -69,7 +69,7 @@ executing==2.2.0
     # via stack-data
 fastjsonschema==2.21.1
     # via nbformat
-fonttools==4.55.6
+fonttools==4.55.8
     # via fpdf2
     # via matplotlib
 fpdf2==2.8.2
@@ -77,7 +77,7 @@ fqdn==1.5.1
     # via jsonschema
 ghp-import==2.1.0
     # via mkdocs
-griffe==1.5.5
+griffe==1.5.6
     # via mkdocstrings-python
 h11==0.14.0
     # via httpcore
@@ -104,7 +104,7 @@ ipywidgets==8.1.5
     # via jupyter
 isoduration==20.11.0
     # via jsonschema
-isort==5.13.2
+isort==6.0.0
 jedi==0.19.2
     # via ipython
 jinja2==3.1.5
@@ -154,7 +154,7 @@ jupyter-server==2.15.0
     # via notebook-shim
 jupyter-server-terminals==0.5.3
     # via jupyter-server
-jupyterlab==4.3.4
+jupyterlab==4.3.5
     # via jupyter
     # via notebook
 jupyterlab-pygments==0.3.0
@@ -185,7 +185,7 @@ matplotlib-inline==0.1.7
 mergedeep==1.3.4
     # via mkdocs
     # via mkdocs-get-deps
-mistune==3.1.0
+mistune==3.1.1
     # via nbconvert
 mkdocs==1.6.1
     # via mkdocs-autorefs
@@ -204,7 +204,7 @@ mkdocstrings==0.27.0
 mkdocstrings-python==1.13.0
 nbclient==0.10.2
     # via nbconvert
-nbconvert==7.16.5
+nbconvert==7.16.6
     # via jupyter
     # via jupyter-server
 nbformat==5.10.4
@@ -270,12 +270,12 @@ pygments==2.19.1
     # via jupyter-console
     # via mkdocs-material
     # via nbconvert
-pymdown-extensions==10.14.1
+pymdown-extensions==10.14.2
     # via mkdocs-material
     # via mkdocstrings
 pyparsing==3.2.1
     # via matplotlib
-pypdf==5.1.0
+pypdf==5.2.0
     # via tinyvdiff
 pytest==8.3.4
     # via pytest-cov
@@ -296,7 +296,7 @@ pyyaml==6.0.2
     # via pyyaml-env-tag
 pyyaml-env-tag==0.1
     # via mkdocs
-pyzmq==26.2.0
+pyzmq==26.2.1
     # via ipykernel
     # via jupyter-client
     # via jupyter-console
@@ -319,7 +319,7 @@ rfc3986-validator==0.1.1
 rpds-py==0.22.3
     # via jsonschema
     # via referencing
-ruff==0.9.3
+ruff==0.9.4
 send2trash==1.8.3
     # via jupyter-server
 setuptools==75.8.0

--- a/requirements.lock
+++ b/requirements.lock
@@ -16,7 +16,7 @@ packaging==24.2
     # via pytest
 pluggy==1.5.0
     # via pytest
-pypdf==5.1.0
+pypdf==5.2.0
     # via tinyvdiff
 pytest==8.3.4
     # via tinyvdiff


### PR DESCRIPTION
This PR replaces the relative path logo with an absolute URL following the PyTorch repo example, so that the image can be rendered properly on PyPI.