### PR TITLE
Update SVG snapshots using pdf2svg 0.2.4

### DIFF
--- a/tests/snapshots/snapshot_fpdf2.svg
+++ b/tests/snapshots/snapshot_fpdf2.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="595.28" height="841.89" viewBox="0 0 595.28 841.89">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="595.28pt" height="841.89pt" viewBox="0 0 595.28 841.89">
 <defs>
 <g>
 <g id="glyph-0-0">

--- a/tests/snapshots/snapshot_matplotlib.svg
+++ b/tests/snapshots/snapshot_matplotlib.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="432" height="288" viewBox="0 0 432 288">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="432pt" height="288pt" viewBox="0 0 432 288">
 <defs>
 <g>
 <g id="glyph-0-0">


### PR DESCRIPTION
This PR updates the SVG snapshots generated by pdf2svg 0.2.4 (updated on Homebrew today).

This update won't affect other platforms because the relevant tests are already only running on macOS only.