### PR TITLE
Set file encoding to UTF-8 explicitly

### DIFF
--- a/src/tinyvdiff/snapshot.py
+++ b/src/tinyvdiff/snapshot.py
@@ -32,8 +32,8 @@ def compare_svgs(generated_svg_path: Path | str, snapshot_svg_path: Path | str) 
         True if the SVGs match after normalization, False otherwise.
     """
     with (
-        open(generated_svg_path) as gen_file,
-        open(snapshot_svg_path) as snap_file,
+        open(generated_svg_path, encoding="utf-8") as gen_file,
+        open(snapshot_svg_path, encoding="utf-8") as snap_file,
     ):
         gen_svg = normalize_svg(gen_file.read())
         snap_svg = normalize_svg(snap_file.read())

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -37,7 +37,7 @@ def test_get_pdf_page_count_missing_file(tmp_path):
 
 def test_get_pdf_page_count_invalid_file(tmp_path):
     invalid_pdf = tmp_path / "invalid.pdf"
-    invalid_pdf.write_text("This is not a PDF file")
+    invalid_pdf.write_text("This is not a PDF file", encoding="utf-8")
 
     with pytest.raises(ValueError):
         get_pdf_page_count(invalid_pdf)

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -19,7 +19,7 @@ def sample_svg_content():
 def sample_svg_file(tmp_path, sample_svg_content):
     """Pytest fixture providing a sample SVG file"""
     svg_file = tmp_path / "test.svg"
-    svg_file.write_text(sample_svg_content)
+    svg_file.write_text(sample_svg_content, encoding="utf-8")
     return svg_file
 
 
@@ -51,8 +51,8 @@ def test_compare_svgs_identical(tmp_path, sample_svg_content):
     svg1 = tmp_path / "svg1.svg"
     svg2 = tmp_path / "svg2.svg"
 
-    svg1.write_text(sample_svg_content)
-    svg2.write_text(sample_svg_content)
+    svg1.write_text(sample_svg_content, encoding="utf-8")
+    svg2.write_text(sample_svg_content, encoding="utf-8")
 
     assert compare_svgs(svg1, svg2)
 
@@ -62,11 +62,11 @@ def test_compare_svgs_different_ids(tmp_path, sample_svg_content):
     svg1 = tmp_path / "svg1.svg"
     svg2 = tmp_path / "svg2.svg"
 
-    svg1.write_text(sample_svg_content)
+    svg1.write_text(sample_svg_content, encoding="utf-8")
     modified_content = sample_svg_content.replace(
         'id="unique_123"', 'id="different_123"'
     )
-    svg2.write_text(modified_content)
+    svg2.write_text(modified_content, encoding="utf-8")
 
     assert compare_svgs(svg1, svg2)
 
@@ -76,9 +76,9 @@ def test_compare_svgs_different_content(tmp_path, sample_svg_content):
     svg1 = tmp_path / "svg1.svg"
     svg2 = tmp_path / "svg2.svg"
 
-    svg1.write_text(sample_svg_content)
+    svg1.write_text(sample_svg_content, encoding="utf-8")
     modified_content = sample_svg_content.replace('width="80"', 'width="90"')
-    svg2.write_text(modified_content)
+    svg2.write_text(modified_content, encoding="utf-8")
 
     assert not compare_svgs(svg1, svg2)
 
@@ -88,11 +88,11 @@ def test_update_snapshot(tmp_path, sample_svg_content):
     source = tmp_path / "source.svg"
     snapshot = tmp_path / "snapshots" / "test.svg"
 
-    source.write_text(sample_svg_content)
+    source.write_text(sample_svg_content, encoding="utf-8")
     update_snapshot(source, snapshot)
 
     assert snapshot.exists()
-    assert snapshot.read_text() == sample_svg_content
+    assert snapshot.read_text(encoding="utf-8") == sample_svg_content
 
 
 def test_update_snapshot_creates_dirs(tmp_path, sample_svg_content):
@@ -100,8 +100,8 @@ def test_update_snapshot_creates_dirs(tmp_path, sample_svg_content):
     source = tmp_path / "source.svg"
     snapshot = tmp_path / "nested" / "directory" / "test.svg"
 
-    source.write_text(sample_svg_content)
+    source.write_text(sample_svg_content, encoding="utf-8")
     update_snapshot(source, snapshot)
 
     assert snapshot.exists()
-    assert snapshot.read_text() == sample_svg_content
+    assert snapshot.read_text(encoding="utf-8") == sample_svg_content


### PR DESCRIPTION
Python's text I/O defaults to the platform locale (e.g. UTF-8 on Unix, cp1252 on some Windows setups), so omitting `encoding` can cause SVG reads/writes to misbehave across machines.

This PR:

- Specify explicit UTF-8 encoding when normalizing/reading SVGs so snapshot comparisons always use the same encoding.
- Updated test helpers to write/read SVG and temp files with UTF-8 to mirror the production behavior and avoid locale-dependent flakes.