### PR TITLE
Set letter-spacing to normal for body text

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -64,6 +64,7 @@ body {
 
 .md-typeset {
     font-size: 1rem;
+    letter-spacing: normal;
 }
 
 .md-path {


### PR DESCRIPTION
This PR resets `letter-spacing` to `normal` for body text on the Zensical site, while keeps the smaller letter spacing applied to h1 and h2 titles unchanged.